### PR TITLE
Rename mpmpid to pid

### DIFF
--- a/programs.cfg
+++ b/programs.cfg
@@ -1,5 +1,5 @@
 {
-  ["mpmpid"] = {
+  ["pid"] = {
     files = {
       ["master/home/bin/pid.lua"] = "/bin",
       ["master/home/bin/gpid.lua"] = "/bin",


### PR DESCRIPTION
I only had it named mpmpid to make it clear it was not mine. However, I still have a package with the same name in my repo, so it would be nice if the official one was named pid. I will update my programs to use the official one soon.
